### PR TITLE
Updated Rmd template to allow passing in document title

### DIFF
--- a/R/examples/VWP_CIA_Summary.Rmd
+++ b/R/examples/VWP_CIA_Summary.Rmd
@@ -1,7 +1,7 @@
 ---
 date: "`r format(Sys.time(), '%m/%d/%Y')`"
 author: ""
-title: "VWP CIA Summary - [INSERT PROJECT NAME HERE]"
+title: "`r params$doc_title`"
 output: 
   officedown::rdocx_document:
     mapstyles:
@@ -14,6 +14,7 @@ output:
       header: 0.0
       footer: 0.0
 params: 
+  doc_title: "VWP CIA Summary - [INSERT PROJECT NAME HERE]"
   rseg.hydroid: 68327 # Ex: Crooked Run = 476998, SF Powell below BSG = 477140, SF Powell at dam: 462757
   fac.hydroid: 73112 # Ex: Blue Ridge Shadows = 71977, BIG STONE GAP WTP = 72672: "runid_6014"
   runid.list: [ "runid_400","runid_600" ]


### PR DESCRIPTION
- See new param `doc_title`
- Example syntax: 
```
rmarkdown::render('C:/Users/nrf46657/Desktop/GitHub/vahydro/R/examples/VWP_CIA_Summary.Rmd',
                  output_file = 'C:/Users/nrf46657/Desktop/GitHub/vahydro/R/examples/Salem_TE',
                  params = list(doc_title = "VWP CIA Summary - Salem WTP",
                                rseg.hydroid = 68327,
                                fac.hydroid = 73112,
                                runid.list = c("runid_2011","runid_4011","runid_600"),
                                rseg.metric.list = c("Qout","l30_Qout","l90_Qout","consumptive_use_frac",
                                                               "wd_cumulative_mgd","ps_cumulative_mgd",
                                                               "wd_mgd","ps_mgd"),
                                intake_stats_runid = 11,
                                preferred_runid = "runid_600",
                                upstream_rseg_ids=c(67839,68105,442254,68331),
                                downstream_rseg_ids=c(68099,68376,68126),
                                users_metric = "base_demand_mgy")
                  )
```